### PR TITLE
Lower webhook alert threshold

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/hook_alert.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/hook_alert.libsonnet
@@ -11,12 +11,12 @@
               (sum(increase(prow_webhook_counter[1m])) == 0 or absent(prow_webhook_counter))
               and ((day_of_week() > 0) and (day_of_week() < 6) and (hour() >= 16))
             |||,
-            'for': '5m',
+            'for': '30m',
             labels: {
               severity: 'slack',
             },
             annotations: {
-              message: 'There have been no webhook calls on working hours for 5 minutes',
+              message: 'There have been no webhook calls on working hours for 30 minutes',
             },
           },
         ],


### PR DESCRIPTION
"Every 5 minutes" is a little too often. We're getting alerts about what is probably just normal activity:
https://istio.slack.com/archives/C0117SL0XHU/p1602874278000600

Lowering threshold to check 30 minute windows.